### PR TITLE
Add apihub-kind for signal types

### DIFF
--- a/artifacts/apihub-taxonomies.yaml
+++ b/artifacts/apihub-taxonomies.yaml
@@ -114,3 +114,24 @@ data:
         - id: apihub-unmanaged
           displayName: Unmanaged
           description: ""
+    - id: apihub-kind
+      displayName: Kind
+      description: Kind of API entry
+      adminApplied: false
+      singleSelection: false
+      searchExcluded: false
+      systemManaged: false
+      displayOrder: 5
+      elements:
+        - id: enrolled
+          displayName: enrolled
+          description: Enrolled API
+        - id: traffic
+          displayName: traffic
+          description: Traffic Signal
+        - id: gateway
+          displayName: gateway
+          description: Gateway Signal
+        - id: product
+          displayName: product
+          description: Product Signal


### PR DESCRIPTION
This adds an `apihub-kind` taxonomy, which allows the API Hub UI to easily filter on entry types (enrolled, product, proxy, traffic, etc). 

We had discussed splitting this information into two labels (`kind` and `signal-type`), but that makes filtering more complex, so let's revisit that in the future.
