### PR TITLE
Add build info for "registry-kit" utility container

### DIFF
--- a/.github/workflows/composite/build-push/action.yml
+++ b/.github/workflows/composite/build-push/action.yml
@@ -1,0 +1,70 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Build and Push image'
+description: 'Composite action to generate registry images'
+inputs:
+  registry:
+    description: 'Image registry to use'
+    required: true
+    default: 'ghcr.io'
+  username:
+    description: 'Username to the image registry'
+    required: true
+  password:
+    description: 'Password for the image registry'
+    required: true
+  image:
+    description: 'Docker image to build'
+    required: true
+  context:
+    description: 'Context to docker build'
+    required: true
+    default: "."
+  file:
+    description: 'Path to the docker file relative to context'
+    required: true
+  build-args:
+    description: 'Build arguments for docker'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Log into registry ${{ env.REGISTRY }}
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=tag
+          type=schedule,pattern=nightly
+          type=raw,latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.file }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: ${{ inputs.build-args }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish docker images
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # each 12:00 UTC
+  push:
+    branches: [ main ]
+    tags: [ 'v*.*.*' ] # semver release
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  USERNAME: ${{ github.actor }}
+  PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  DOCKER_REPOSITORY_OWNER: ${{github.repository_owner}}
+
+jobs:
+
+  build-registry-kit:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - uses: ./.github/workflows/composite/build-push
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ env.USERNAME }}
+        password: ${{ env.PASSWORD }}
+        image: ${{ env.DOCKER_REPOSITORY_OWNER }}/registry-kit
+        context: .
+        file: containers/registry-kit/Dockerfile

--- a/containers/registry-kit/Dockerfile
+++ b/containers/registry-kit/Dockerfile
@@ -1,0 +1,99 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile builds an image that contains tools for working with a registry.
+
+# Use the official Golang image to create a build artifact.
+# This is based on Debian and sets the GOPATH to /go.
+# https://hub.docker.com/_/golang
+FROM golang:1.20.1 as builder
+RUN apt-get update
+RUN apt-get install unzip
+
+### Build Go-based tools ###
+WORKDIR /
+RUN CGO_ENABLED=0 GOOS=linux go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
+RUN CGO_ENABLED=0 GOOS=linux go install github.com/googleapis/api-linter/cmd/api-linter@latest
+
+### BUILD REGISTRY ###
+
+# Get the latest registry source code
+WORKDIR /
+RUN git clone https://github.com/apigee/registry
+
+# Work in the registry directory
+WORKDIR /registry
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+RUN go mod download
+
+# Build registry tool and plugins.
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry \
+    ./cmd/registry
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry-lint-api-linter \
+    ./cmd/registry/plugins/registry-lint-api-linter
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry-lint-spectral \
+    ./cmd/registry/plugins/registry-lint-spectral
+
+### BUILD REGISTRY-EXPERIMENTAL ###
+
+# Get the latest registry-experimental source code
+WORKDIR /
+RUN git clone https://github.com/apigee/registry-experimental
+
+# Work in the registry-experimental directory
+WORKDIR /registry-experimental
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+RUN go mod download
+
+# Build registry-experimental.
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o registry-experimental \
+    ./cmd/registry-experimental
+
+### BUILD THE CONTAINER ###
+
+# Use the official Alpine image for a lean production container.
+# https://hub.docker.com/_/alpine
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM alpine:3
+RUN apk update && apk upgrade
+RUN apk add --no-cache ca-certificates
+
+# Add some commonly-needed tools to the image.
+RUN apk add --no-cache bash git yq jq
+
+# Copy binaries from the builder stage.
+COPY --from=builder /registry/registry /usr/local/bin/registry
+COPY --from=builder /registry/registry-lint-api-linter /usr/local/bin/registry-lint-api-linter
+COPY --from=builder /registry/registry-lint-spectral /usr/local/bin/registry-lint-spectral
+COPY --from=builder /registry-experimental/registry-experimental /usr/local/bin/registry-experimental
+
+# Install node-based tools.
+RUN apk add --no-cache nodejs npm
+RUN npm install -g @stoplight/spectral-cli
+RUN npm install -g api-spec-converter
+RUN npm install -g swagger2openapi
+
+# Install protoc.
+RUN apk add curl gcompat
+COPY --from=builder /registry/tools/PROTOC-VERSION.sh ./tools/PROTOC-VERSION.sh
+COPY --from=builder /registry/tools/FETCH-PROTOC.sh ./tools/FETCH-PROTOC.sh
+RUN ./tools/FETCH-PROTOC.sh
+
+# Copy installed Go tools from the builder stage.
+COPY --from=builder /go/bin/protoc-gen-openapi /usr/local/bin/protoc-gen-openapi
+COPY --from=builder /go/bin/api-linter /usr/local/bin/api-linter

--- a/containers/registry-kit/README.md
+++ b/containers/registry-kit/README.md
@@ -1,0 +1,3 @@
+# registry-kit
+
+A container for running various jobs on an API registry.


### PR DESCRIPTION
This adds a Dockerfile and a GitHub action to build a container with some extra utilities that we will use in the demo.