### PR TITLE
Add lifecycle stages for observations

### DIFF
--- a/artifacts/apihub-lifecycle.yaml
+++ b/artifacts/apihub-lifecycle.yaml
@@ -41,3 +41,18 @@ data:
       description: API no longer available for use
       url: ""
       displayOrder: 6
+    - id: observed-product
+      displayName: Observed Product
+      description: An Apigee API Product
+      url: ""
+      displayOrder: 7
+    - id: observed-proxy
+      displayName: Observed Proxy
+      description: An Apigee API Proxy
+      url: ""
+      displayOrder: 8
+    - id: observed-traffic
+      displayName: Observed Traffic
+      description: An Apigee Traffic Observation
+      url: ""
+      displayOrder: 9


### PR DESCRIPTION
This adds lifecycle stages to represent observations.

Observations are independent of lifecycle -- they exist in the system and if they did have a lifecycle stage, it would be inherited from whatever API they are associated with. 

It's debatable whether or not to set the lifecycle of "bound" observations to their inherited values, but for unbound observations, this puts more informative values in their lifecycle fields than simply leaving those fields blank.
